### PR TITLE
add `--union` flag (fixes #26)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ test/data
 test/data-without-markers
 test/minimap*-new/*
 !test/minimap*-new/.gitkeep
+test/data*-new/*
+!test/data*-new/.gitkeep
 
 # 0x flamecharts
 *.0x

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -35,6 +35,7 @@ const main = async () => {
 		console.log('\nUsage:\n');
 		console.log(`\t${info.name} --from-minimap=./minimap --output-dir=./data`);
 		console.log(`\t${info.name} --from-minimap=./minimap --output-dir=./data --markers-only`);
+		console.log(`\t${info.name} --from-minimap=./minimap --output-dir=./data --markers-only --union`);
 		console.log(`\t${info.name} --from-data=./data --output-dir=./minimap --no-markers`);
 		console.log(`\t${info.name} --from-data=./data --output-dir=./minimap-grid --overlay-grid`);
 		console.log(`\t${info.name} --from-data=./data --extra=achievements,orcsoberfest --output-dir=./minimap`);

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -71,9 +71,10 @@ const main = async () => {
 		if (!markersOnly) {
 			await emptyDirectory(dataDirectory);
 		}
+		const unionMode = argv['union'];
 		const bounds = await generateBoundsFromMinimap(mapsDirectory, dataDirectory, !markersOnly);
 		convertFromMinimap(
-			bounds, mapsDirectory, dataDirectory, !excludeMarkers, markersOnly
+			bounds, mapsDirectory, dataDirectory, !excludeMarkers, markersOnly, unionMode
 		);
 		return;
 	}

--- a/test/data-union-base/markers.json
+++ b/test/data-union-base/markers.json
@@ -1,6 +1,6 @@
 [
 	{
-		"description": "Stone Golems",
+		"description": "Stoner",
 		"icon": "red down",
 		"x": 32098,
 		"y": 31371,

--- a/test/data-union-base/markers.json
+++ b/test/data-union-base/markers.json
@@ -1,0 +1,16 @@
+[
+	{
+		"description": "Stone Golems",
+		"icon": "red down",
+		"x": 32098,
+		"y": 31371,
+		"z": 8
+	},
+	{
+		"description": "Start",
+		"icon": "star",
+		"x": 33051,
+		"y": 33694,
+		"z": 8
+	}
+]

--- a/test/data-union/markers.json
+++ b/test/data-union/markers.json
@@ -1,0 +1,30 @@
+[
+	{
+		"description": "Foo’s ïñtërnâtiônàlizætiøn workshop",
+		"icon": "star",
+		"x": 32064,
+		"y": 31883,
+		"z": 5
+	},
+	{
+		"description": "Buddel",
+		"icon": "flag",
+		"x": 32021,
+		"y": 31294,
+		"z": 8
+	},
+	{
+		"description": "Stone Golems",
+		"icon": "red down",
+		"x": 32098,
+		"y": 31371,
+		"z": 8
+	},
+	{
+		"description": "Start",
+		"icon": "star",
+		"x": 33051,
+		"y": 33694,
+		"z": 8
+	}
+]

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -1,8 +1,9 @@
+import { copyFileSync, fstat } from 'node:fs';
 import { execSync } from 'node:child_process';
 import { dirname } from 'node:path';
 import { chdir } from 'node:process';
 import { fileURLToPath } from 'node:url';
-import { compareDir, readFile } from './util.mjs';
+import { compareDir, compareMarkerFiles, readFile } from './util.mjs';
 
 chdir(dirname(fileURLToPath(import.meta.url)));
 
@@ -32,3 +33,9 @@ const markers = JSON.parse(readFile('data-without-markers/markers.json'));
 if (markers.length > 0) {
 	console.error('Error: `--no-markers` extracted marker data anyway! (data-without-markers/markers.json)');
 }
+
+
+// Check if `--union` works correctly.
+copyFileSync('data-union-base/markers.json', 'data-union-new/markers.json');
+execSync('tibia-maps --union --markers-only --from-minimap=minimap --output-dir=data-union-new');
+compareMarkerFiles('data-union');

--- a/test/util.mjs
+++ b/test/util.mjs
@@ -8,7 +8,7 @@ export function compareMarkerFiles(dir, newDir = `${dir}-new`) {
 	const maxIndex = Math.max(markers.length, newMarkers.length);
 
 	for (let i = 0; i < maxIndex; i++) {
-		if (!compareMarkers(markers[i], newMarkers[i])) {
+		if (!isMarkerEqual(markers[i], newMarkers[i])) {
 			const markerJson = JSON.stringify(markers[i], null, 4);
 			const newMarkerJson = JSON.stringify(newMarkers[i], null, 4);
 
@@ -40,7 +40,7 @@ export function readFile(file) {
 	}
 }
 
-function compareMarkers(markerA, markerB) {
+function isMarkerEqual(markerA, markerB) {
 	return markerA != null && markerB != null
 		&& markerA.description === markerB.description
 		&& markerA.icon === markerB.icon

--- a/test/util.mjs
+++ b/test/util.mjs
@@ -1,6 +1,29 @@
 import { createHash } from 'node:crypto';
 import { readdirSync, readFileSync } from 'node:fs';
 
+export function compareMarkerFiles(dir, newDir = `${dir}-new`) {
+	const markers = JSON.parse(readFile(`${dir}/markers.json`));
+	const newMarkers = JSON.parse(readFile(`${newDir}/markers.json`));
+
+	const maxIndex = Math.max(markers.length, newMarkers.length);
+
+	for (let i = 0; i < maxIndex; i++) {
+		if (!compareMarkers(markers[i], newMarkers[i])) {
+			const markerJson = JSON.stringify(markers[i], null, 4);
+			const newMarkerJson = JSON.stringify(newMarkers[i], null, 4);
+
+			console.error(`Marker mismatch at index ${i}:`);
+			console.info(`## EXPECTED (${dir}/markers.json)`);
+			console.info(markerJson);
+			console.info(`## ACTUAL (${newDir}/markers.json)`);
+			console.info(newMarkerJson);
+			return false;
+		}
+	}
+
+	return true;
+}
+
 export function compareDir(dir, newDir = `${dir}-new`, extensions = ['png', 'bin']) {
 	for (const file of readdirSync(dir)) {
 		if (extensions.some(ext => file.endsWith(`.${ext}`))) {
@@ -11,10 +34,19 @@ export function compareDir(dir, newDir = `${dir}-new`, extensions = ['png', 'bin
 
 export function readFile(file) {
 	try {
-		return readFileSync(file);
+		return readFileSync(file).toString();
 	} catch (e) {
 		return null;
 	}
+}
+
+function compareMarkers(markerA, markerB) {
+	return markerA != null && markerB != null
+		&& markerA.description === markerB.description
+		&& markerA.icon === markerB.icon
+		&& markerA.x === markerB.x
+		&& markerA.y === markerB.y
+		&& markerA.z === markerB.z;
 }
 
 function compare(file1, file2) {


### PR DESCRIPTION
This adds the option to pass the `--union` flag which instead of overwriting, merges origin and destination markers, as per describe in #26.

This implementation only tackles convert minimap -> json, as that's where I see this being most useful. If we find the need to, I can work on an implementation for the other direction too, but since I've been postponing this for a while I wanted to get at least this out asap.

Let me know if there's anything you'd like changed.